### PR TITLE
Allow user to supply via attribute whether they want the indicator enabled

### DIFF
--- a/dist/brick-tabbar.js
+++ b/dist/brick-tabbar.js
@@ -102,9 +102,7 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
-    if (!tabbar.noindicator) {
-      _placeIndicator(tabEl);
-    }
+    _placeIndicator(tabEl);
   }
 
   function _placeIndicator(tabEl) {
@@ -121,6 +119,13 @@
       indicator.style.webkitTransform = 'translateX(' + 100 * index + '%)';
       indicator.style.transform = 'translateX(' + 100 * index + '%)';
     }
+  }
+
+  function _hideIndicator(tabbar) {
+    tabbar.selectedIndicator.style.display = "none";
+  }
+  function _showIndicator(tabbar) {
+    tabbar.selectedIndicator.style.display = "block";
   }
 
   var BrickTabbarElementPrototype = Object.create(HTMLElement.prototype);
@@ -168,6 +173,11 @@
       }
     }
 
+    // initially show/hide the indicator
+    if (this.noindicator) {
+      _hideIndicator(this);
+    }
+
     // check for new tabs being added and call selectTab() again,
     // to correct the size of the indicator
     var observer = new MutationObserver(function(mutations) {
@@ -179,6 +189,21 @@
       });
     });
     observer.observe(this, { childList: true });
+
+    // check for the noindicator property being added/removed
+    var observer2 = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (mutation.type === "attributes" && mutation.attributeName === 'noindicator') {
+          var tabbar = mutation.target;
+          if (tabbar.noindicator) {
+            _hideIndicator(tabbar);
+          } else {
+            _showIndicator(tabbar);
+          }
+        }
+      });
+    });
+    observer2.observe(this, { attributes: true });
   };
 
   BrickTabbarElementPrototype.detachedCallback = function() {

--- a/dist/brick-tabbar.js
+++ b/dist/brick-tabbar.js
@@ -102,7 +102,7 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
-    if (tabbar.hasIndicator) {
+    if (!tabbar.noindicator) {
       _placeIndicator(tabEl);
     }
   }
@@ -206,9 +206,9 @@
         return this.querySelector('brick-tabbar-tab[selected]');
       }
     },
-    'hasIndicator': {
+    'noindicator': {
       get: function() {
-        return this.getAttribute('indicator') !== 'disabled';
+        return this.hasAttribute('noindicator');
       }
     }
   });

--- a/dist/brick-tabbar.js
+++ b/dist/brick-tabbar.js
@@ -54,11 +54,7 @@
     },
     'targetElement': {
       get: function() {
-        if (this.overrideElement) {
-          return this.overrideElement;
-        } else {
-          return document.getElementById(this.target);
-        }
+        return this.overrideElement ||  document.getElementById(this.target);
       },
       set: function(newVal) {
         this.overrideElement = newVal;
@@ -106,6 +102,13 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
+    if (tabbar.hasIndicator) {
+      _placeIndicator(tabEl);
+    }
+  }
+
+  function _placeIndicator(tabEl) {
+    var tabbar = tabEl.parentNode;
     var index = tabbar.tabs.indexOf(tabEl);
     var indicator = tabbar.selectedIndicator;
 
@@ -201,6 +204,11 @@
     'selectedTab': {
       get: function() {
         return this.querySelector('brick-tabbar-tab[selected]');
+      }
+    },
+    'hasIndicator': {
+      get: function() {
+        return this.getAttribute('indicator') !== 'disabled';
       }
     }
   });

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
     <hr>
 
-    <brick-tabbar id="demo-bar" indicator="disabled">
+    <brick-tabbar id="demo-bar" noindicator>
       <brick-tabbar-tab target="a" selected>
         <i class="fa fa-camera-retro"></i>
       </brick-tabbar-tab>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,20 @@
 
     <hr>
 
+    <brick-tabbar id="demo-bar" indicator="disabled">
+      <brick-tabbar-tab target="a" selected>
+        <i class="fa fa-camera-retro"></i>
+      </brick-tabbar-tab>
+      <brick-tabbar-tab target="b">
+        <i class="fa fa-envelope"></i>
+      </brick-tabbar-tab>
+      <brick-tabbar-tab target="c">
+        <i class="fa fa-home"></i>
+      </brick-tabbar-tab>
+    </brick-tabbar>
+
+    <hr>
+
     <brick-tabbar id="demo-bar">
       <brick-tabbar-tab target="a" selected>
         <i class="fa fa-camera-retro"></i> Camera

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Attribute     | Options     | Default      | Description
 Property            | Type        | Default      | Description
 ---                 | ---         | ---          | ---
 `target-event`      | *string*    | `reveal`     | Corresponds to the `target-event` attribute.
-`indicator`         | *string*    | null         | A value of `disabled` will prevent display of the indicator.
+`noindicator`       | *boolean*   | -            | Adding the attribute `disabled` will prevent display of the indicator.
 `tabs` (getter only)| *array*     | -            | Returns a list of the `<brick-tabbar-tab>` elements in the `<brick-tabbar>`.
 
 ## brick-tabbar-tab details

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ Attribute     | Options     | Default      | Description
 Property            | Type        | Default      | Description
 ---                 | ---         | ---          | ---
 `target-event`      | *string*    | `reveal`     | Corresponds to the `target-event` attribute.
+`indicator`         | *string*    | null         | A value of `disabled` will prevent animation of the indicator.
 `tabs` (getter only)| *array*     | -            | Returns a list of the `<brick-tabbar-tab>` elements in the `<brick-tabbar>`.
 
 ## brick-tabbar-tab details

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Attribute     | Options     | Default      | Description
 Property            | Type        | Default      | Description
 ---                 | ---         | ---          | ---
 `target-event`      | *string*    | `reveal`     | Corresponds to the `target-event` attribute.
-`indicator`         | *string*    | null         | A value of `disabled` will prevent animation of the indicator.
+`indicator`         | *string*    | null         | A value of `disabled` will prevent display of the indicator.
 `tabs` (getter only)| *array*     | -            | Returns a list of the `<brick-tabbar-tab>` elements in the `<brick-tabbar>`.
 
 ## brick-tabbar-tab details

--- a/src/tabbar.js
+++ b/src/tabbar.js
@@ -29,9 +29,7 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
-    if (!tabbar.noindicator) {
-      _placeIndicator(tabEl);
-    }
+    _placeIndicator(tabEl);
   }
 
   function _placeIndicator(tabEl) {
@@ -48,6 +46,13 @@
       indicator.style.webkitTransform = 'translateX(' + 100 * index + '%)';
       indicator.style.transform = 'translateX(' + 100 * index + '%)';
     }
+  }
+
+  function _hideIndicator(tabbar) {
+    tabbar.selectedIndicator.style.display = "none";
+  }
+  function _showIndicator(tabbar) {
+    tabbar.selectedIndicator.style.display = "block";
   }
 
   var BrickTabbarElementPrototype = Object.create(HTMLElement.prototype);
@@ -95,6 +100,11 @@
       }
     }
 
+    // initially show/hide the indicator
+    if (this.noindicator) {
+      _hideIndicator(this);
+    }
+
     // check for new tabs being added and call selectTab() again,
     // to correct the size of the indicator
     var observer = new MutationObserver(function(mutations) {
@@ -106,6 +116,21 @@
       });
     });
     observer.observe(this, { childList: true });
+
+    // check for the noindicator property being added/removed
+    var observer2 = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (mutation.type === "attributes" && mutation.attributeName === 'noindicator') {
+          var tabbar = mutation.target;
+          if (tabbar.noindicator) {
+            _hideIndicator(tabbar);
+          } else {
+            _showIndicator(tabbar);
+          }
+        }
+      });
+    });
+    observer2.observe(this, { attributes: true });
   };
 
   BrickTabbarElementPrototype.detachedCallback = function() {

--- a/src/tabbar.js
+++ b/src/tabbar.js
@@ -29,6 +29,13 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
+    if (tabbar.hasIndicator) {
+      _placeIndicator(tabEl);
+    }
+  }
+
+  function _placeIndicator(tabEl) {
+    var tabbar = tabEl.parentNode;
     var index = tabbar.tabs.indexOf(tabEl);
     var indicator = tabbar.selectedIndicator;
 
@@ -124,6 +131,11 @@
     'selectedTab': {
       get: function() {
         return this.querySelector('brick-tabbar-tab[selected]');
+      }
+    },
+    'hasIndicator': {
+      get: function() {
+        return this.getAttribute('indicator') !== 'disabled';
       }
     }
   });

--- a/src/tabbar.js
+++ b/src/tabbar.js
@@ -29,7 +29,7 @@
     tabEl.setAttribute('selected', true);
 
     // move the indicator
-    if (tabbar.hasIndicator) {
+    if (!tabbar.noindicator) {
       _placeIndicator(tabEl);
     }
   }
@@ -133,9 +133,9 @@
         return this.querySelector('brick-tabbar-tab[selected]');
       }
     },
-    'hasIndicator': {
+    'noindicator': {
       get: function() {
-        return this.getAttribute('indicator') !== 'disabled';
+        return this.hasAttribute('noindicator');
       }
     }
   });


### PR DESCRIPTION
Fixes #21 (or so I hope)

Hi there

`indicator="disabled"` in this PR will allow the user to declare whether they want the indicator animating or not
Ideally, the indicator element itself would be hidden entirely (this is not the case)

I wasn't entirely sure how to expose an attribute/property that a user could call externally (via inspect &  `$0.indicator` or otherwise), and the code here looks quite different than https://developer.mozilla.org/en-US/Apps/Tools_and_frameworks/Web_components so I figured I'd start this PR to start the conversation

Let me know what you think
